### PR TITLE
Adding Dockerfile for tmpreaper, adding Helm chart to run tmpreaper in a daily CronJob.

### DIFF
--- a/helm/haste/Chart.yaml
+++ b/helm/haste/Chart.yaml
@@ -1,2 +1,2 @@
 name: haste
-version: 0.0.1
+version: 0.0.2

--- a/helm/haste/templates/cronjob.yaml
+++ b/helm/haste/templates/cronjob.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.haste.volume }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: tmpreaper
+spec:
+  schedule: "0 0 */1 * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: tmpreaper
+            image: {{ required "must provide a docker repository" .Values.haste.repository }}/{{ .Values.tmpreaper.image }}:{{ .Values.tmpreaper.tag }}
+            command:
+             - "tmpreaper"
+             - {{ required "must provide an interval" .Values.tmpreaper.interval }}
+             - {{ required "must provide a storage path" .Values.haste.storage.path }}
+            volumeMounts:
+              - name: nfs-rtp-tmpreaper                
+                mountPath: {{ required "must provide a storage path" .Values.haste.storage.path }}
+          restartPolicy: OnFailure
+          volumes:
+          - name: nfs-rtp-tmpreaper
+            persistentVolumeClaim:
+              claimName: {{ required "must provide a volume name" .Values.haste.volume.name }}-haste-0
+{{ end }}

--- a/helm/haste/templates/cronjob.yaml
+++ b/helm/haste/templates/cronjob.yaml
@@ -1,10 +1,12 @@
 {{ if .Values.haste.volume }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v2alpha1
 kind: CronJob
 metadata:
   name: tmpreaper
 spec:
   schedule: "0 0 */1 * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:

--- a/helm/haste/values.yaml
+++ b/helm/haste/values.yaml
@@ -3,8 +3,12 @@ haste:
   tag: latest
   storage:
     type: 'file'
-    path: './data'
+    path: '/haste/data'
   # For a persistent volume claim, provide values like these:
-  #volume:
-  #  name: volume-name
-  #  size: 50Gi
+  volume:
+    name: haste-volume
+    size: 50Gi
+tmpreaper:
+  image: tmpreaper
+  tag: latest
+  interval: '7d'

--- a/tmpreaper/Dockerfile
+++ b/tmpreaper/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:xenial
+RUN apt-get update -qq && apt-get install -y tmpreaper
+
+FROM alpine:latest
+COPY --from=0 /usr/sbin/tmpreaper /bin/tmpreaper
+COPY --from=0 /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=0 /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+VOLUME /haste/data


### PR DESCRIPTION
I haven't done a multi-stage build for now - we need to install cron/anacron as well as tmpreaper, and the complexity of manually maintaining all of the install steps for multiple packages didn't seem worth the smaller image size. Happy to go that route if you feel otherwise!

I also noticed that Kubernetes has its own CronJob entity - I could look into wiring up tmpreaper to work with that instead of cron.